### PR TITLE
Fix href/url naming

### DIFF
--- a/examples/links-in-portabletext/react-portableText.js
+++ b/examples/links-in-portabletext/react-portableText.js
@@ -9,7 +9,7 @@ const serializers = {
     },
     externalLink: ({mark, children}) => {
       // Read https://css-tricks.com/use-target_blank/
-      const { blank, url } = mark
+      const { blank, href } = mark
       return blank ?
         <a href={url} target="_blank" rel="noopener">{children}</a>
         : <a href={url}>{children}</a>

--- a/examples/links-in-portabletext/react-portableText.js
+++ b/examples/links-in-portabletext/react-portableText.js
@@ -11,8 +11,8 @@ const serializers = {
       // Read https://css-tricks.com/use-target_blank/
       const { blank, href } = mark
       return blank ?
-        <a href={url} target="_blank" rel="noopener">{children}</a>
-        : <a href={url}>{children}</a>
+        <a href={href} target="_blank" rel="noopener">{children}</a>
+        : <a href={href}>{children}</a>
     }
   }
 }


### PR DESCRIPTION
See[ portableText.js](https://github.com/sanity-io/sanity-recipes/blob/master/examples/links-in-portabletext/portableText.js); external link URL name is 'href'.